### PR TITLE
fix: lifetime problem, using Higher Ranked Trait Bounds

### DIFF
--- a/src/datastructures.rs
+++ b/src/datastructures.rs
@@ -1,4 +1,4 @@
-pub trait FromQueryString<'de> : Deserialize<'de> {
+pub trait FromQueryString: for<'de> Deserialize<'de> {
     fn from_query(data: &str) -> anyhow::Result<Self>
     where
         Self: Sized;
@@ -39,7 +39,7 @@ pub mod channel {
         }
     }
 
-    impl FromQueryString<'_> for Channel {
+    impl FromQueryString for Channel {
         fn from_query(data: &str) -> anyhow::Result<Self>
         where
             Self: Sized,
@@ -86,7 +86,7 @@ pub mod client {
         }
     }
 
-    impl FromQueryString<'_> for Client {
+    impl FromQueryString for Client {
         fn from_query(data: &str) -> anyhow::Result<Self>
         where
             Self: Sized,

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ impl TelnetConn {
         Ok((None, content))
     }
 
-    fn decode_status_with_result<'de, T: FromQueryString<'de> + Sized>(
+    fn decode_status_with_result<T: FromQueryString + Sized>(
         data: Box<[u8]>,
     ) -> anyhow::Result<(Option<QueryStatus>, Option<Vec<T>>)> {
         let (status, content) = Self::decode_status(data)?;


### PR DESCRIPTION
We can fix it with Higher Ranked Trait Bounds,
which means, for all possible lifetime `'de`, satisfied it.
```rust
trait FromQueryString: for<'de> Deserialize<'de>
```

Ref: https://doc.rust-lang.org/nomicon/hrtb.html